### PR TITLE
chore: try releasing 13.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@
 /tmp-*/
 
 /.vscode/ltex.*.txt
-/.vscode/settings.json
 
 !/lib/.keep
 /.venv

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+	"terminal.integrated.env.linux": {
+		"DONT_PROMPT_WSL_INSTALL": "1"
+	}
+}

--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@
 [![stars](https://badgen.net/github/stars/valentjn/ltex-ls)](https://github.com/valentjn/ltex-ls)&nbsp;
 [![open issues](https://badgen.net/github/open-issues/valentjn/ltex-ls?label=open/closed%20issues&color=blue)](https://github.com/valentjn/ltex-ls/issues)&nbsp;[![closed issues](https://badgen.net/github/closed-issues/valentjn/ltex-ls?label=)](https://github.com/valentjn/ltex-ls/issues)
 
+NOTICE: This is a fork of [@valentjn's vscode-ltex](https://github.com/valentjn/vscode-ltex) as it seems to be not maintained.
+
+The current version 13.1.0 is identical to the original.
+It serves as a base version before adding fixes and improvements.
+
 <!-- #if TARGET == 'vscode' -->
 **LT<sub>E</sub>X** provides offline grammar checking of various markup languages in Visual Studio Code using [LanguageTool (LT)](https://languagetool.org/). LT<sub>E</sub>X currently supports BibT<sub>E</sub>X, ConT<sub>E</sub>Xt, L<sup>A</sup>T<sub>E</sub>X, Markdown, Org, reStructuredText, R Sweave, and XHTML documents. In addition, LT<sub>E</sub>X can check comments in many popular programming languages (optional, opt-in).
 <!-- #elseif TARGET == 'coc.nvim' -->

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "vscode-neo-ltex",
+  "name": "@neo-ltex/vscode-ltex",
   "displayName": "LTeX – LanguageTool grammar/spell checking (neo)",
-  "version": "13.1.1-alpha.1.develop",
+  "version": "13.1.0",
   "description": "Grammar/spell checker using LanguageTool with support for LaTeX, Markdown, and others",
   "categories": [
     "Linters",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@neo-ltex/vscode-ltex",
+  "name": "ltex",
   "displayName": "LTeX – LanguageTool grammar/spell checking (neo)",
   "version": "13.1.0",
   "description": "Grammar/spell checker using LanguageTool with support for LaTeX, Markdown, and others",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vscode-ltex",
+  "name": "ltex",
   "displayName": "LTeX – LanguageTool grammar/spell checking (neo)",
   "version": "13.1.0",
   "description": "Grammar/spell checker using LanguageTool with support for LaTeX, Markdown, and others",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ltex",
+  "name": "vscode-ltex",
   "displayName": "LTeX – LanguageTool grammar/spell checking (neo)",
   "version": "13.1.0",
   "description": "Grammar/spell checker using LanguageTool with support for LaTeX, Markdown, and others",

--- a/src/BugReporter.ts
+++ b/src/BugReporter.ts
@@ -30,7 +30,7 @@ export default class BugReporter {
   private static readonly _maxNumberOfConfigLines: number = 1000;
   private static readonly _maxNumberOfServerLogLines: number = 100;
   private static readonly _maxNumberOfClientLogLines: number = 1000;
-  private static readonly _bugReportUrl: string = 'https://github.com/valentjn/vscode-ltex/'
+  private static readonly _bugReportUrl: string = 'https://github.com/neo-ltex/vscode-ltex/'
       + 'issues/new?assignees=&labels=1-bug%20%F0%9F%90%9B%2C+2-unconfirmed&'
       + 'template=bug-report.md&title=&body=';
 
@@ -126,7 +126,7 @@ export default class BugReporter {
     // deprecated: replace with self._context.extension starting with VS Code 1.55.0
     const extension: Code.Extension<any> | undefined =
     // #if TARGET == 'vscode'
-        Code.extensions.getExtension('valentjn.vscode-ltex');
+        Code.extensions.getExtension('neo-ltex.ltex');
     // #elseif TARGET == 'coc.nvim'
         // Code.extensions.all.find(
             // (extension: Code.Extension<Code.ExtensionApi>) => extension.id == 'coc-ltex');

--- a/src/CommandHandler.ts
+++ b/src/CommandHandler.ts
@@ -47,7 +47,7 @@ export default class CommandHandler {
   private _languageClient: CodeLanguageClient.LanguageClient | null;
   private _externalFileManager: ExternalFileManager;
 
-  private static readonly _featureRequestUrl: string = 'https://github.com/valentjn/vscode-ltex/'
+  private static readonly _featureRequestUrl: string = 'https://github.com/neo-ltex/vscode-ltex/'
       + 'issues/new?assignees=&labels=1-feature-request%20%E2%9C%A8&'
       + 'template=feature-request.md&title=';
 

--- a/src/DependencyManager.ts
+++ b/src/DependencyManager.ts
@@ -58,7 +58,7 @@ export default class DependencyManager {
     // deprecated: replace with context.extension starting with VS Code 1.55.0
     const vscodeLtexExtension: Code.Extension<any> | undefined =
         // #if TARGET == 'vscode'
-        Code.extensions.getExtension('valentjn.vscode-ltex');
+        Code.extensions.getExtension('neo-ltex.ltex');
         // #elseif TARGET == 'coc.nvim'
         // Code.extensions.all.find(
           // (extension: Code.Extension<Code.ExtensionApi>) => extension.id == 'coc-ltex');

--- a/test/ExtensionInitializer.ts
+++ b/test/ExtensionInitializer.ts
@@ -19,7 +19,7 @@ export default class ExtensionInitializer {
     if (ExtensionInitializer._languageClient != null) return Promise.resolve();
 
     const ltex: Code.Extension<Ltex.Api> | undefined =
-        Code.extensions.getExtension('valentjn.vscode-ltex');
+        Code.extensions.getExtension('neo-ltex.ltex');
     if (ltex == null) return Promise.reject(new Error('Could not find LTeX.'));
 
     Code.workspace.getConfiguration('ltex').update('trace.server', 'messages',

--- a/test/TestRunner.ts
+++ b/test/TestRunner.ts
@@ -90,7 +90,7 @@ async function runTestIteration(testIteration: number): Promise<void> {
       console.log(`Removing '${ltexLibDirPath}'...`);
       Rimraf.sync(ltexLibDirPath);
       const ltexOfflineLibDirPath: string =
-          Path.join(extensionsDirPath, `valentjn.vscode-ltex-${ltexVersion}`, 'lib');
+          Path.join(extensionsDirPath, `neo-ltex.ltex-${ltexVersion}`, 'lib');
       console.log(`Moving '${ltexOfflineLibDirPath}' to '${ltexLibDirPath}'...`);
       Fs.renameSync(ltexOfflineLibDirPath, ltexLibDirPath);
     }

--- a/tools/createOfflinePackages.py
+++ b/tools/createOfflinePackages.py
@@ -81,7 +81,7 @@ def createPackage(ltexPlatform: Optional[str] = None, ltexArch: Optional[str] = 
     packageName = f"vscode-ltex-{ltexVersion}-offline-{ltexPlatform}-{ltexArch}.vsix"
 
   assert re.match(r"^[\-\.0-9A-Z_a-z]+$", packageName) is not None
-  cmd = f"vsce package -o \"{packageName}\""
+  cmd = f"npx vsce package -o \"{packageName}\""
   print(f"Creating package by running '{cmd}'...")
   subprocess.run(cmd, shell=True)
 


### PR DESCRIPTION
Try releasing 13.1.0 as a base release.

The purpose is to setup a base release version and iron out the releasing process.

After this, the code will change and refactored to separate the code for different release targets, and other architectural concerns.