### PR TITLE
fix: issues neo-ltex/vscode-ltex#45 and neo-ltex/vscode-ltex#23

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ The current version 13.1.0 is identical to the original.
 It serves as a base version before adding fixes and improvements.
 
 <!-- #if TARGET == 'vscode' -->
-**LT<sub>E</sub>X** provides offline grammar checking of various markup languages in Visual Studio Code using [LanguageTool (LT)](https://languagetool.org/). LT<sub>E</sub>X currently supports BibT<sub>E</sub>X, ConT<sub>E</sub>Xt, L<sup>A</sup>T<sub>E</sub>X, Markdown, Org, reStructuredText, R Sweave, and XHTML documents. In addition, LT<sub>E</sub>X can check comments in many popular programming languages (optional, opt-in).
+**LT<sub>E</sub>X** provides offline grammar checking of various markup languages in Visual Studio Code using [LanguageTool (LT)](https://languagetool.org/). LT<sub>E</sub>X currently supports BibT<sub>E</sub>X, ConT<sub>E</sub>Xt, L<sup>A</sup>T<sub>E</sub>X, Markdown, Org, reStructuredText, R Sweave, Typst, and XHTML documents. In addition, LT<sub>E</sub>X can check comments in many popular programming languages (optional, opt-in).
 <!-- #elseif TARGET == 'coc.nvim' -->
-<!-- **LT<sub>E</sub>X** provides offline grammar checking of various markup languages in Vim/Neovim using [LanguageTool (LT)](https://languagetool.org/) and [coc.nvim](https://github.com/neoclide/coc.nvim). LT<sub>E</sub>X currently supports BibT<sub>E</sub>X, ConT<sub>E</sub>Xt, L<sup>A</sup>T<sub>E</sub>X, Markdown, Org, reStructuredText, R Sweave, and XHTML documents. In addition, LT<sub>E</sub>X can check comments in many popular programming languages (optional, opt-in). -->
+<!-- **LT<sub>E</sub>X** provides offline grammar checking of various markup languages in Vim/Neovim using [LanguageTool (LT)](https://languagetool.org/) and [coc.nvim](https://github.com/neoclide/coc.nvim). LT<sub>E</sub>X currently supports BibT<sub>E</sub>X, ConT<sub>E</sub>Xt, L<sup>A</sup>T<sub>E</sub>X, Markdown, Org, reStructuredText, R Sweave, Typst, and XHTML documents. In addition, LT<sub>E</sub>X can check comments in many popular programming languages (optional, opt-in). -->
 <!-- #endif -->
 
 The difference to regular spell checkers is that LT<sub>E</sub>X not only detects spelling errors, but also many grammar and stylistic errors such as:
@@ -57,7 +57,7 @@ LT<sub>E</sub>X is a successor (since it's a fork) of the abandoned [LanguageToo
 
 ![Grammar/Spell Checker for VS Code with LanguageTool and LaTeX Support](https://github.com/valentjn/vscode-ltex/raw/release/img/banner-ltex.png)
 
-- **Supported markup languages:** BibT<sub>E</sub>X, ConT<sub>E</sub>Xt, L<sup>A</sup>T<sub>E</sub>X, Markdown, Org, reStructuredText, R Sweave, XHTML
+- **Supported markup languages:** AsciiDoc, BibT<sub>E</sub>X, ConT<sub>E</sub>Xt, L<sup>A</sup>T<sub>E</sub>X, Markdown, Org, reStructuredText, R Sweave, Typst, XHTML
 - Comment checking in **many popular programming languages** (optional, opt-in)
 - Comes with **everything included,** no need to install Java or LanguageTool
 - **Offline checking:** Does not upload anything to the internet

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
           ],
           "scope": "window",
           "default": [
+            "asciidoc",
             "bibtex",
             "context",
             "context.tex",
@@ -127,7 +128,8 @@
             "markdown",
             "org",
             "restructuredtext",
-            "rsweave"
+            "rsweave",
+            "typst"
           ],
           "markdownDescription": "%ltex.i18n.configuration.ltex.enabled.markdownDescription%",
           "examples": [
@@ -2615,6 +2617,7 @@
     "onCommand:ltex.requestFeature",
     "onCommand:_ltex.openMarkdownExample",
     "onCommand:_ltex.openLatexExample",
+    "onLanguage:asciidoc",
     "onLanguage:bibtex",
     "onLanguage:context",
     "onLanguage:context.tex",
@@ -2624,6 +2627,7 @@
     "onLanguage:org",
     "onLanguage:restructuredtext",
     "onLanguage:rsweave",
+    "onLanguage:typst",
     "onNotebook:*"
   ],
   "dependencies": {

--- a/src/CommandHandler.ts
+++ b/src/CommandHandler.ts
@@ -52,6 +52,7 @@ export default class CommandHandler {
       + 'template=feature-request.md&title=';
 
   private static readonly _defaultCodeLanguageIds: string[] = [
+		'asciidoc',
     'bibtex',
     'context',
     'context.tex',
@@ -61,6 +62,7 @@ export default class CommandHandler {
     'org',
     'restructuredtext',
     'rsweave',
+		'typst'
   ];
 
   public constructor(context: Code.ExtensionContext, externalFileManager: ExternalFileManager,
@@ -302,6 +304,11 @@ export default class CommandHandler {
 
     for (const codeLanguageId of enabledCodeLanguageIds) {
       switch (codeLanguageId) {
+				case 'asciidoc': {
+          enabledFileExtensions.add('adoc');
+					enabledFileExtensions.add('asciidoc');
+          break;
+        }
         case 'bibtex': {
           enabledFileExtensions.add('bib');
           break;
@@ -483,6 +490,10 @@ export default class CommandHandler {
         }
         case 'typescript': {
           enabledFileExtensions.add('ts');
+          break;
+        }
+				case 'typst': {
+          enabledFileExtensions.add('typ');
           break;
         }
         case 'vb': {


### PR DESCRIPTION
## Description

This commit provides basic support for Typst and AsciiDoc. I build a .VSIX file and tested it locally in VS Code using Windows. Since both Typst and AsciiDoc are not supported by LTEX LS, false negatives occur may occur.

## Checklist

* [x] Have you read the [guidelines on contributing code to LT<sub>E</sub>X](https://valentjn.github.io/ltex/vscode-ltex/contributing.html#how-to-contribute-code)?
* [ ] Have you filled in all missing information in this pull request template?
* [ ] Have you written new tests for your changes, if applicable?
* [ ] Do your changes pass all [code checks](https://valentjn.github.io/ltex/vscode-ltex/contributing.html#code-checks) such as linting and tests?
